### PR TITLE
docs: fix url to example app

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This package currently provides support for Firebase out of the box but allows d
 ### Install
 
 ```sh
-npx create-next-app crossmint-solana-auth --example "https://github.com/crossmint/solana-auth/packages/examples/nextjs-starter"
+npx create-next-app crossmint-solana-auth --example "https://github.com/crossmint/solana-auth/tree/main/packages/examples/nextjs-starter"
 
 cd crossmint-solana-auth && yarn install
 yarn dev


### PR DESCRIPTION
First of all - thanks for sharing this project, this looks great!

When trying the demo I ran into an error though, this patch fixes it.

```
$ npx create-next-app crossmint-solana-auth --example "https://github.com/crossmint/solana-auth/packages/examples/nextjs-starter"
Need to install the following packages:
  create-next-app
Ok to proceed? (y)
Found invalid GitHub URL: "https://github.com/crossmint/solana-auth/packages/examples/nextjs-starter". Please fix the URL and try again.
```